### PR TITLE
Add 0x Tracker to love.yml

### DIFF
--- a/_data/love.yml
+++ b/_data/love.yml
@@ -44,3 +44,5 @@
 - name: Pinky UI
   link: "https://www.pinkyui.com"
   
+- name: 0x Tracker
+  link: "https://0xtracker.com"


### PR DESCRIPTION
Staticaly is being used on the Tokens page of 0x Tracker (https://0xtracker.com/tokens) to ensure token images have proper cache headers. Token images are being pulled from https://github.com/TrustWallet/tokens via the Github API but images served via the Github CDN don't have appropriate cache headers.